### PR TITLE
Allowing "expand" parameter

### DIFF
--- a/es6/index.js
+++ b/es6/index.js
@@ -110,7 +110,6 @@ export default class Confluency {
 
 
   _getPagesAll(query, pages=[]) {
-    console.log("gPA", query);
     return this.GET(query).then(body => {
       pages = pages.concat(body.results);
       if (!body._links.next) return pages;
@@ -121,7 +120,6 @@ export default class Confluency {
 
   // https://docs.atlassian.com/atlassian-confluence/REST/latest/#space-contentsWithType
   getPages(spaceKey, opts={limit: 25,expand: []}) {
-      console.log("gp", opts);
     return Promise.resolve().then(() => {
       const query = '/space/' + spaceKey + '/content/page';
       if (!opts.all) return this.GET(query).then(body => body.results);


### PR DESCRIPTION
This also pulls all query string code out (except for search) into a
single function so the rest of the code can benefit and have additional
parameters fed into the API URIs.

Addresses #16.